### PR TITLE
Fixed the creation of an empty category

### DIFF
--- a/src/OPMLCore.NET/OPMLCore.NET.csproj
+++ b/src/OPMLCore.NET/OPMLCore.NET.csproj
@@ -2,6 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>1.0.1</Version>
+    <PackageProjectUrl>https://github.com/fnya/OPMLCore.NET</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/fnya/OPMLCore.NET</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <Authors>fnya</Authors>
+    <Company>fnya</Company>
+    <Description>OPMLCore.NET is OPML Parser which easy to use for .NET Core Applications.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>opml</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/OPMLCore.NET/Outline.cs
+++ b/src/OPMLCore.NET/Outline.cs
@@ -125,7 +125,7 @@ namespace OPMLCore.NET {
         private List<string> GetCategoriesAtrribute(XmlElement element, string name)
         {
                 List<string> list = new List<string>();
-                var items = element.GetAttribute(name).Split(',');
+                var items = element.GetAttribute(name).Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach(var item in items) 
                 {
                     list.Add(item.Trim());

--- a/test/UnitTest1.cs
+++ b/test/UnitTest1.cs
@@ -247,5 +247,40 @@ namespace test
 
             Assert.True(opml.ToString() == xml.ToString());
         }
+
+        [Fact]
+        public void TestOptionalCategory()
+        {
+            StringBuilder xml = new StringBuilder();
+            xml.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
+            xml.Append("<opml version=\"2.0\">");
+            xml.Append("<head>");
+            xml.Append("<title>mySubscriptions.opml</title>");
+            xml.Append("<dateCreated>Sat, 18 Jun 2005 12:11:52 GMT</dateCreated>");
+            xml.Append("</head>");
+            xml.Append("<body>");
+            xml.Append("<outline ");
+            xml.Append("text=\"CNET News.com\" ");
+            xml.Append("type=\"rss\" ");
+            xml.Append("xmlUrl=\"http://news.com.com/2547-1_3-0-5.xml\" ");
+            xml.Append("/>");
+            xml.Append("</body>");
+            xml.Append("</opml>");
+
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml.ToString());
+            Opml opml = new Opml(doc);
+
+            Assert.True(opml.Head.Title == "mySubscriptions.opml");
+            Assert.True(opml.Head.DateCreated == DateTime.Parse("Sat, 18 Jun 2005 12:11:52 GMT"));
+            Assert.True(opml.Head.ExpansionState.Count == 0);
+
+            foreach (var outline in opml.Body.Outlines) {
+                Assert.True(outline.Text == "CNET News.com");
+                Assert.True(outline.Category.Count == 0);
+                Assert.True(outline.Type == "rss");
+                Assert.True(outline.XMLUrl == "http://news.com.com/2547-1_3-0-5.xml");
+            }
+        }
     }
 }

--- a/test/UnitTest1.cs
+++ b/test/UnitTest1.cs
@@ -249,7 +249,7 @@ namespace test
         }
 
         [Fact]
-        public void TestOptionalCategory()
+        public void OptionalCategoryTest()
         {
             StringBuilder xml = new StringBuilder();
             xml.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");


### PR DESCRIPTION
If an `<outline>` tag in the source document did not have any `category` attribute, an empty category was added to the resulting OPML object.

In the OPML specification, `category` is optional.

I added the `StringSplitOptions.RemoveEmptyEntries` flag when reading the source data.