### PR TITLE
Fixed XML special characters not replaced by entities

### DIFF
--- a/src/OPMLCore.NET/Head.cs
+++ b/src/OPMLCore.NET/Head.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Xml;
 using System.Collections.Generic;
+using System.Security;
 
 namespace OPMLCore.NET {
     public class Head 
@@ -181,7 +182,7 @@ namespace OPMLCore.NET {
             {
                 return string.Empty;
             } else {
-                return $"<{name}>{value}</{name}>\r\n";
+                return $"<{name}>{SecurityElement.Escape(value)}</{name}>\r\n";
             }
         }
         private string GetNodeString(string name, DateTime? value)

--- a/src/OPMLCore.NET/Outline.cs
+++ b/src/OPMLCore.NET/Outline.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Xml;
 using System.Collections.Generic;
+using System.Security;
 
 namespace OPMLCore.NET {
     public class Outline 
@@ -170,7 +171,7 @@ namespace OPMLCore.NET {
             {
                 return string.Empty;
             } else {
-                return $" {name}=\"{value}\"";
+                return $" {name}=\"{SecurityElement.Escape(value)}\"";
             }
         }
 
@@ -193,7 +194,7 @@ namespace OPMLCore.NET {
             StringBuilder buf = new StringBuilder();
             foreach (var item in value)
             {
-                buf.Append(item);
+                buf.Append(SecurityElement.Escape(item));
                 buf.Append(",");
             }
             

--- a/test/UnitTest1.cs
+++ b/test/UnitTest1.cs
@@ -247,5 +247,37 @@ namespace test
 
             Assert.True(opml.ToString() == xml.ToString());
         }
+
+        [Fact]
+        public void EntitiesTest() {
+            Opml opml = new Opml();
+            opml.Encoding = "UTF-8";
+            opml.Version = "2.0";
+
+            opml.Head.Title = "Things & Stuff";
+            opml.Head.OwnerName = "Me, myself & I";
+
+            Outline outline = new Outline();
+            outline.Text = "Things & Stuff News";
+            outline.Category.Add("Things & Stuff");
+            outline.Description = "Things & Stuff News";
+            outline.Title = "Things & Stuff News";
+
+            opml.Body.Outlines.Add(outline);
+
+            StringBuilder xml = new StringBuilder();
+            xml.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n");
+            xml.Append("<opml version=\"2.0\">\r\n");
+            xml.Append("<head>\r\n");
+            xml.Append("<title>Things &amp; Stuff</title>\r\n");
+            xml.Append("<ownerName>Me, myself &amp; I</ownerName>\r\n");
+            xml.Append("</head>\r\n");
+            xml.Append("<body>\r\n");
+            xml.Append("<outline text=\"Things &amp; Stuff News\" category=\"Things &amp; Stuff\" description=\"Things &amp; Stuff News\" title=\"Things &amp; Stuff News\" />\r\n");
+            xml.Append("</body>\r\n");
+            xml.Append("</opml>");
+
+            Assert.True(opml.ToString() == xml.ToString());
+        }
     }
 }


### PR DESCRIPTION
XML reserved characters were not correctly replaced by entities in the generated XML string.

I added a call to [`SecurityElement.Escape`](https://docs.microsoft.com/en-us/dotnet/api/system.security.securityelement.escape) whenever plain text was allowed by OPML specifications.