### PR TITLE
Added OPML namespace support

### DIFF
--- a/src/OPMLCore.NET/Opml.cs
+++ b/src/OPMLCore.NET/Opml.cs
@@ -4,6 +4,8 @@ using System.Xml;
 
 namespace OPMLCore.NET {
     public class Opml {
+        private const string NAMESPACE_URI = "http://opml.org/spec2";
+
         ///<summary>
         /// Version of OPML
         ///</summary>
@@ -13,6 +15,11 @@ namespace OPMLCore.NET {
         /// Encoding of OPML
         ///</summary>
         public string Encoding { get; set;}
+
+        /// <summary>
+        /// Include namespace in XML
+        /// </summary>
+        public bool UseNamespace { get; set;}
 
         ///<summary>
         /// Head of OPML
@@ -81,7 +88,13 @@ namespace OPMLCore.NET {
             String ecoding = string.IsNullOrEmpty(Encoding)?"UTF-8":Encoding;
             buf.Append($"<?xml version=\"1.0\" encoding=\"{ecoding}\" ?>\r\n");
             String version = string.IsNullOrEmpty(Version)?"2.0":Version;
-            buf.Append($"<opml version=\"{version}\">\r\n");
+
+            if (UseNamespace) {
+                buf.Append($"<opml version=\"{version}\" xmlns=\"{NAMESPACE_URI}\">\r\n");
+            } else {
+                buf.Append($"<opml version=\"{version}\">\r\n");
+            }
+
             buf.Append(Head.ToString());
             buf.Append(Body.ToString());
             buf.Append("</opml>");

--- a/test/UnitTest1.cs
+++ b/test/UnitTest1.cs
@@ -247,5 +247,39 @@ namespace test
 
             Assert.True(opml.ToString() == xml.ToString());
         }
+
+        [Fact]
+        public void WithNamespaceTest() {
+            Opml opml = new Opml();
+            opml.Encoding = "UTF-8";
+            opml.Version = "2.0";
+            opml.UseNamespace = true;
+
+            Head head = new Head();
+            head.Title = "mySubscriptions.opml";
+            opml.Head = head;
+
+            Outline outline = new Outline();
+            outline.Text = "CNET News.com";
+
+            Body body = new Body();
+            body.Outlines.Add(outline);
+            opml.Body = body;
+
+            StringBuilder xml = new StringBuilder();
+            xml.Append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n");
+            xml.Append("<opml version=\"2.0\" xmlns=\"http://opml.org/spec2\">\r\n");
+            xml.Append("<head>\r\n");
+            xml.Append("<title>mySubscriptions.opml</title>\r\n");
+            xml.Append("</head>\r\n");
+            xml.Append("<body>\r\n");
+            xml.Append("<outline ");
+            xml.Append("text=\"CNET News.com\" ");
+            xml.Append("/>\r\n");
+            xml.Append("</body>\r\n");
+            xml.Append("</opml>");
+
+            Assert.True(opml.ToString() == xml.ToString());
+        }
     }
 }


### PR DESCRIPTION
I added the possibility to include XML Namespace for OPML in the generated string.

`<opml  version="2.0" xmlns="http://opml.org/spec2">`

The option uses a boolean property `UseNamespace`in the `OPML` class, which defaults to `false`.